### PR TITLE
Use same versions for environment

### DIFF
--- a/Dockerfile.kubeadm
+++ b/Dockerfile.kubeadm
@@ -1,6 +1,6 @@
-FROM debian
+FROM debian:10
 
-ARG RELEASE=v1.17.0
+ARG RELEASE=v1.17.2
 
 ADD https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/kubeadm \
     /usr/local/bin/kubeadm

--- a/Dockerfile.kubeadm
+++ b/Dockerfile.kubeadm
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:9
 
 ARG RELEASE=v1.17.2
 

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,10 +1,10 @@
-FROM debian:9
+FROM debian:10
 
-ARG K8S_RELEASE=v1.17.1
+ARG K8S_RELEASE=v1.17.
 ARG CNI_RELEASE=v0.8.4
 
 RUN apt-get update && \
-    apt-get install -y iptables conntrack procps net-tools bash apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
+    apt-get install -y iptables conntrack procps net-tools apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get update && \

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,6 +1,6 @@
-FROM debian:10
+FROM debian:9
 
-ARG K8S_RELEASE=v1.17.
+ARG K8S_RELEASE=v1.17.2
 ARG CNI_RELEASE=v0.8.4
 
 RUN apt-get update && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
   #3-deploy kube-apiserver.
   #https://kubernetes.io/docs/reference/using-api/api-overview/
   kube-apiserver:
-    image: gcr.io/google-containers/kube-apiserver:v1.16.4
+    image: gcr.io/google-containers/kube-apiserver:v1.17.2
     deploy:
       restart_policy:
         condition: on-failure
@@ -200,7 +200,7 @@ services:
   #https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#synopsis
   kube-controller-manager:
     hostname: kube-controller-manager
-    image: gcr.io/google-containers/kube-controller-manager:v1.16.4
+    image: gcr.io/google-containers/kube-controller-manager:v1.17.2
     deploy:
       restart_policy:
         condition: on-failure
@@ -260,7 +260,7 @@ services:
   #6-deploy kube-scheduler
   #https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/#synopsis
   kube-scheduler:
-    image: gcr.io/google-containers/kube-scheduler:v1.16.4
+    image: gcr.io/google-containers/kube-scheduler:v1.17.2
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
The Kubernetes components should be the same version
The base image should be the same for stability too

Bash is already in the debian base image so I deleted it from apt-get